### PR TITLE
g-w service logs and 30gb free

### DIFF
--- a/modules/fluentd/templates/fluentd.conf.erb
+++ b/modules/fluentd/templates/fluentd.conf.erb
@@ -26,8 +26,8 @@
 <source>
   @type tail
   read_from_head true
-  path /var/log/genericworker/stderr.log
-  pos_file /var/log/genericworker/stderr.log.pos
+  path /var/opt/generic-worker/service.stderr.log
+  pos_file /var/opt/generic-worker/service.stderr.log.pos
   <parse>
     @type multiline
     # 2019/11/07 18:41:43 Disk available: 225110376448 bytes\n
@@ -42,8 +42,8 @@
 <source>
   @type tail
   read_from_head true
-  path /var/log/genericworker/stdout.log
-  pos_file /var/log/genericworker/stdout.log.pos
+  path /var/opt/generic-worker/service.stdout.log
+  pos_file /var/opt/generic-worker/service.stdout.log.pos
   <parse>
     @type multiline
     # 2019/11/07 18:41:43 Disk available: 225110376448 bytes\n

--- a/modules/fluentd/templates/td-agent.plist.erb
+++ b/modules/fluentd/templates/td-agent.plist.erb
@@ -12,6 +12,10 @@
     <string>--log</string>
     <string>/var/log/td-agent/td-agent.log</string>
     <string>--use-v1-config</string>
+    <string>--log-rotate-size</string>
+    <string>104857600</string>
+    <string>--log-rotate-age</string>
+    <string>2</string>
     <string>-qq</string>
   </array>
   <key>RunAtLoad</key>

--- a/modules/generic_worker/templates/generic-worker.config.multiuser.erb
+++ b/modules/generic_worker/templates/generic-worker.config.multiuser.erb
@@ -15,7 +15,7 @@
   "privateIP": "",
   "provisionerId": "releng-hardware",
   "region": "",
-  "requiredDiskSpaceMegabytes": 20480,
+  "requiredDiskSpaceMegabytes": 30720,
   "rootURL": "https://firefox-ci-tc.services.mozilla.com",
   "runAfterUserCreation": "",
   "runTasksAsCurrentUser": false,

--- a/modules/generic_worker/templates/run-generic-worker.sh.multiuser.erb
+++ b/modules/generic_worker/templates/run-generic-worker.sh.multiuser.erb
@@ -65,6 +65,9 @@ else
 fi
 
 echo "REBOOT $(date)"
+# launchd does not limit the service log file size. truncate it
+> /var/opt/generic-worker/service.stdout.log
+> /var/opt/generic-worker/service.stderr.log
 <%= @reboot_command %>
 # Sleep to prevent this script from terminating naturally, and launchd restarting
 # it. Instead, the shutdown should cause this script to terminate (so it won't


### PR DESCRIPTION
* forward the generic-worker wrapper service logs (includes the g-w running log)
* increase to 30gb free required (builds require more than 20gb).

The builders have been running with these two changes.